### PR TITLE
fix: add `"type": "module"`, use `exports` field & bump version

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-import torchlight from './src/torchlight'
-import Block from './src/block'
+import torchlight from './src/torchlight.js'
+import Block from './src/block.js'
 
 export {
   torchlight,

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
     "name": "@torchlight-api/torchlight-cli",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "A CLI for Torchlight - the syntax highlighting API",
-    "main": "index.js",
+	"type": "module",
+    "exports": "index.js",
     "scripts": {
         "test": "standard --env jest && jest",
         "build": "babel src --out-dir lib --copy-files \"--ignore\" \"src/stubs/**/*\""

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.3",
     "description": "A CLI for Torchlight - the syntax highlighting API",
 	"type": "module",
-    "exports": "index.js",
+    "exports": "./index.js",
     "scripts": {
         "test": "standard --env jest && jest",
         "build": "babel src --out-dir lib --copy-files \"--ignore\" \"src/stubs/**/*\""

--- a/src/bin/torchlight.js
+++ b/src/bin/torchlight.js
@@ -1,4 +1,4 @@
 #! /usr/bin/env node
-import { makeProgram } from '../cli'
+import { makeProgram } from '../cli.js'
 
 makeProgram().parse()

--- a/src/block.js
+++ b/src/block.js
@@ -1,6 +1,6 @@
 import md5 from 'md5'
-import guid from './support/guid'
-import torchlight from './torchlight'
+import guid from './support/guid.js'
+import torchlight from './torchlight.js'
 
 export default function Block (opts = {}) {
   opts = {

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,9 +1,9 @@
 import { program } from 'commander'
-import torchlight from './torchlight'
-import highlight from './commands/highlight'
-import init from './commands/init'
-import cacheClear from './commands/cache/clear'
-import { makeConfig, makeCache } from './config'
+import torchlight from './torchlight.js'
+import highlight from './commands/highlight.js'
+import init from './commands/init.js'
+import cacheClear from './commands/cache/clear.js'
+import { makeConfig, makeCache } from './config.js'
 
 /**
  * Configure the commander CLI application.

--- a/src/commands/highlight.js
+++ b/src/commands/highlight.js
@@ -1,11 +1,11 @@
 import path from 'path'
-import torchlight from '../torchlight'
-import Block from '../block'
+import torchlight from '../torchlight.js'
+import Block from '../block.js'
 import cheerio from 'cheerio'
 import chokidar from 'chokidar'
-import log from '../support/log'
+import log from '../support/log.js'
 import fs from 'fs-extra'
-import { bus, FILE_WATCHING_COMPLETE } from '../support/bus'
+import { bus, FILE_WATCHING_COMPLETE } from '../support/bus.js'
 
 export default function (torchlight, options) {
   options = {

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -1,7 +1,7 @@
 import fs from 'fs-extra'
 import path from 'path'
 import inquirer from 'inquirer'
-import log from '../support/log'
+import log from '../support/log.js'
 
 function write (location) {
   const source = path.resolve(path.join(__dirname, '../stubs/config.js'))

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,7 @@
 import fs from 'fs-extra'
 import path from 'path'
-import FileCache from './cache/file'
-import MemoryCache from './cache/memory'
+import FileCache from './cache/file.js'
+import MemoryCache from './cache/memory.js'
 
 /**
  * @param {string|object} config

--- a/src/torchlight.js
+++ b/src/torchlight.js
@@ -2,8 +2,8 @@ import axios from 'axios'
 import md5 from 'md5'
 import get from 'lodash.get'
 import chunk from 'lodash.chunk'
-import log from './support/log'
-import MemoryCache from './cache/memory'
+import log from './support/log.js'
+import MemoryCache from './cache/memory.js'
 
 /**
  * @constructor

--- a/tests/highlight.test.js
+++ b/tests/highlight.test.js
@@ -1,6 +1,6 @@
-import torchlight from '../src/torchlight';
-import {mockApi, fixture} from './support/helpers';
-import log from '../src/support/log';
+import torchlight from '../src/torchlight.js';
+import {mockApi, fixture} from './support/helpers.js';
+import log from '../src/support/log.js';
 
 process.env.TORCHLIGHT_TOKEN = 'test'
 

--- a/tests/support/helpers.js
+++ b/tests/support/helpers.js
@@ -1,7 +1,7 @@
-import { bus, FILE_WATCHING_COMPLETE } from '../../src/support/bus'
-import { testCli } from '../../src/cli'
 import { readFileSync } from 'fs-extra'
-import torchlight from '../../src/torchlight'
+import { bus, FILE_WATCHING_COMPLETE } from '../../src/support/bus.js'
+import { testCli } from '../../src/cli.js'
+import torchlight from '../../src/torchlight.js'
 
 function fixture (file, callback, options = {}) {
   options = {


### PR DESCRIPTION
This PR correctly makes the package an ESModule